### PR TITLE
Update api_define_npc() sprite dimensions

### DIFF
--- a/main.html
+++ b/main.html
@@ -1859,11 +1859,11 @@ end
       |-
       | walking_h_sprite || {{D|i=string}} || relative path to the sprite you want to use for the NPC when walking and highlighted, should be a 72x18 image with 4 frames (stand, step_1, stand, step_2)
       |-
-      | head_sprite || {{D|i=string}} || relative path to the sprite you want to use for this NPCs map icon, should be a 64x16 image with 4 frames (normal, normal highlighted, undiscovered, undiscovered highlight)
+      | head_sprite || {{D|i=string}} || relative path to the sprite you want to use for this NPCs map icon, should be an 18x14 image with 1 frame
       |-
-      | bust_sprite || {{D|i=string}} || relative path to the sprite you want to use for this item, should be a 18x14 image with 1 frame 
+      | bust_sprite || {{D|i=string}} || relative path to the sprite you want to use for this NPC on the shop menu, should be a 64x36 image with 2 frames (normal, smiling)
       |-
-      | item_sprite || {{D|i=string}} || relative path to the sprite you want to use for this NPCs item (that you get when you hammer an NPC), should be a 64x16 image with 2 frames (normal, normal highlighted)
+      | item_sprite || {{D|i=string}} || relative path to the sprite you want to use for this NPCs item (that you get when you hammer an NPC), should be a 32x16 image with 2 frames (normal, normal highlighted)
       |-
       | dialogue_menu_sprite || {{D|i=string}} || relative path to the sprite you want to use for this NPCs dialogue menu, should be a 648x138 image with 2 frames (normal, normal highlighted) but can technically be any size if you want to mess with it
       |-


### PR DESCRIPTION
- Update head_sprite dimensions to match sample_mod sprite dimensions. Tried 64x16 four frames as stated and it created multiple NPCs on the map in an interesting fashion. 
- Update bust_sprite dimensions to match sample_mod sprite dimensions.
- Update item_sprite dimensions to match sample_mod sprite dimensions.